### PR TITLE
support NumPy array input as well

### DIFF
--- a/itk_cucim/filtering/image_feature.py
+++ b/itk_cucim/filtering/image_feature.py
@@ -6,10 +6,12 @@ import cucim.skimage
 import cupy as cp
 import itk
 import numpy as np
+from itk.support import helpers
 
 from ._discrete_gaussian import discrete_gaussian_derivative_filter
 
 
+@helpers.accept_array_like_xarray_torch
 def cucim_discrete_gaussian_derivative_image_filter(*args, **kwargs):
     input_image = args[0]
     ref_filt = itk.DiscreteGaussianDerivativeImageFilter.New(*args, **kwargs)

--- a/itk_cucim/filtering/image_grid.py
+++ b/itk_cucim/filtering/image_grid.py
@@ -1,10 +1,11 @@
 """cuCIM accelerated filters for the ITKImageGrid module."""
 import cupy as cp
 import itk
-
 from cucim.skimage.transform import downscale_local_mean
+from itk.support import helpers
 
 
+@helpers.accept_array_like_xarray_torch
 def cucim_bin_shrink_image_filter(*args, **kwargs):
     input_image = args[0]
     ref_kwargs = kwargs.copy()

--- a/itk_cucim/filtering/smoothing.py
+++ b/itk_cucim/filtering/smoothing.py
@@ -6,10 +6,12 @@ import cucim.skimage
 import cupy as cp
 import itk
 import numpy as np
+from itk.support import helpers
 
 from ._discrete_gaussian import discrete_gaussian_filter
 
 
+@helpers.accept_array_like_xarray_torch
 def cucim_discrete_gaussian_image_filter(*args, **kwargs):
     input_image = args[0]
     ref_filt = itk.DiscreteGaussianImageFilter.New(*args, **kwargs)
@@ -58,6 +60,7 @@ def cucim_discrete_gaussian_image_filter(*args, **kwargs):
     return wrapper.GetOutput()
 
 
+@helpers.accept_array_like_xarray_torch
 def cucim_median_image_filter(*args, **kwargs):
     input_image = args[0]
     ref_filt = itk.MedianImageFilter.New(*args, **kwargs)

--- a/test/filtering/test_image_grid.py
+++ b/test/filtering/test_image_grid.py
@@ -16,24 +16,32 @@ class TestImageGrid:
         # float32 data
         self.image_f32 = image_u8.astype(np.float32)
 
+    def _compare_bin_shrink(self, image, float_tol=1e-3, **kwargs):
+        floating = np.dtype(image.dtype).kind == 'f'
+        shrink_ref = itk.bin_shrink_image_filter(image, **kwargs)
+        shrink_cucim = image_grid.cucim_bin_shrink_image_filter(
+            image, **kwargs
+        )
+        comparison = itk.comparison_image_filter(
+            shrink_ref, shrink_cucim, verify_input_information=True
+        )
+        if floating:
+            assert np.sum(np.abs(comparison)) <= float_tol
+        else:
+            # ignore difference in integer rounding
+            assert np.max(comparison) <= 1.0
+
     @pytest.mark.parametrize("floating", [False, True])
     @pytest.mark.parametrize("shrink_factors", [1, 2, 3, 7, (4, 3, 2)])
-    def test_median_image_filter(self, shrink_factors, floating):
+    def test_bin_shrink_filter(self, shrink_factors, floating):
         if floating:
             image = self.image_f32
         else:
             image = self.image
         kwargs = dict(shrink_factors=shrink_factors)
-        shrink_ref = itk.bin_shrink_image_filter(image, **kwargs)
-        shrink_cucim = image_grid.cucim_bin_shrink_image_filter(
-            image, **kwargs
-        )
+        self._compare_bin_shrink(image, float_tol=0., **kwargs)
 
-        comparison = itk.comparison_image_filter(
-            shrink_ref, shrink_cucim, verify_input_information=True
-        )
-        if floating:
-            assert np.sum(comparison) == 0.0
-        else:
-            # ignore difference in integer rounding
-            assert np.max(comparison) <= 1.0
+    def test_bin_shrink_filter_numpy_input(self):
+        rng = np.random.default_rng()
+        image = rng.standard_normal((512, 256), dtype=np.float32)
+        self._compare_bin_shrink(image, float_tol=1e-3, shrink_factors=(4, 2))

--- a/test/filtering/test_smoothing.py
+++ b/test/filtering/test_smoothing.py
@@ -19,13 +19,7 @@ class TestSmoothing:
         # float32 data
         self.image_f32 = Caster(image_u8)
 
-    @pytest.mark.parametrize("radius", [1, (3, 2, 1)])
-    @pytest.mark.parametrize("floating", [False, True])
-    def test_median_image_filter(self, radius, floating):
-        if floating:
-            image = self.image_f32
-        else:
-            image = self.image
+    def _compare_median(self, image, radius):
         median_ref = itk.median_image_filter(image, radius=radius)
         median_cucim = smoothing.cucim_median_image_filter(image, radius=radius)
 
@@ -34,19 +28,22 @@ class TestSmoothing:
         )
         assert np.sum(comparison) == 0.0
 
-    @pytest.mark.parametrize("variance", [1, 4, (3, 2, 1)])
-    @pytest.mark.parametrize("use_image_spacing", [False, True])
+    @pytest.mark.parametrize("radius", [1, (3, 2, 1)])
     @pytest.mark.parametrize("floating", [False, True])
-    def test_discrete_gaussian_image_filter(self, variance, use_image_spacing, floating):
+    def test_median_image_filter(self, radius, floating):
         if floating:
             image = self.image_f32
         else:
             image = self.image
-        kwargs = dict(
-            variance=variance,
-            use_image_spacing=use_image_spacing
-        )
+        self._compare_median(image, radius)
 
+    def test_median_image_filter_numpy_input(self):
+        rng = np.random.default_rng()
+        image = rng.standard_normal((512, 256), dtype=np.float32)
+        self._compare_median(image, radius=2)
+
+    def _compare_discrete_gaussian(self, image, **kwargs):
+        floating = np.dtype(image.dtype).kind == 'f'
         gaussian_ref = itk.discrete_gaussian_image_filter(image, **kwargs)
         gaussian_cucim = smoothing.cucim_discrete_gaussian_image_filter(
             image, **kwargs
@@ -63,3 +60,26 @@ class TestSmoothing:
             assert np.max(np.abs(gaussian_ref - gaussian_cucim)) <= 1
         else:
             assert np.max(comparison) < 1e-3
+
+    @pytest.mark.parametrize("variance", [1, 4, (3, 2, 1)])
+    @pytest.mark.parametrize("use_image_spacing", [False, True])
+    @pytest.mark.parametrize("floating", [False, True])
+    def test_discrete_gaussian_image_filter(self, variance, use_image_spacing, floating):
+        if floating:
+            image = self.image_f32
+        else:
+            image = self.image
+        kwargs = dict(
+            variance=variance,
+            use_image_spacing=use_image_spacing
+        )
+        self._compare_discrete_gaussian(image, **kwargs)
+
+    def test_discrete_gaussian_image_filter_numpy_input(self):
+        rng = np.random.default_rng()
+        image = rng.standard_normal((512, 256), dtype=np.float32)
+        kwargs = dict(
+            variance=(3, 2),
+            use_image_spacing=False,
+        )
+        self._compare_discrete_gaussian(image, **kwargs)


### PR DESCRIPTION
In addition to supporting `itk.Image` input, I think the functions in cuCIM should also accept NumPy arrays (and potentially other tensors types such as from Xarray or PyTorch).

To achieve this, I reused an existing decorator called `accept_array_like_xarray_torch` from `itk.support.helpers`. ITK devs: is this considered stable API for ITK's Python package or do we need to vendor a copy of this function in itk-cuCIM?

Test cases using NumPy array input were added for the existing functions.


